### PR TITLE
Fix for bug checking temperature from device

### DIFF
--- a/accessories/aircon.js
+++ b/accessories/aircon.js
@@ -354,8 +354,8 @@ class AirConAccessory extends BroadlinkRMAccessory {
     log(`${name} monitorTemperature`);
 
     // this call appears to be creating duplicate calls and delaying status refreshes
-    // device.on('temperature', this.onTemperature.bind(this));
-    // device.checkTemperature();
+    device.on('temperature', this.onTemperature.bind(this));
+    device.checkTemperature();
 
     this.updateTemperatureUI();
     if (!config.isUnitTest) setInterval(this.updateTemperatureUI.bind(this), config.temperatureUpdateFrequency * 1000)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-broadlink-rm-tv",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Broadlink RM plugin (including the mini and pro) for homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "scripts": {


### PR DESCRIPTION
Fixes #51 

I disabled one device temperature update call that I suspected was creating duplicate calls. I now think this was a quirk in iOS 13.0 and reverted this change.